### PR TITLE
Added z85_encode / z85_decode bindings to context.

### DIFF
--- a/inc/ZMQ2/ContextWrappers.pm
+++ b/inc/ZMQ2/ContextWrappers.pm
@@ -145,6 +145,26 @@ sub curve_keypair {
 }
 )}
 
+sub z85_encode_tt {q(
+sub z85_encode {
+    my ($self) = @_;
+    $self->bad_version(
+        $self->verstr,
+       "z85_encode not available in < zmq 4.x"
+    );
+}
+)}
+
+sub z85_decode_tt {q(
+sub z85_decode {
+    my ($self) = @_;
+    $self->bad_version(
+        $self->verstr,
+       "z85_decode not available in < zmq 4.x"
+    );
+}
+)}
+
 sub has_capability_tt {q(
 sub has_capability {
     my ($self) = @_;

--- a/inc/ZMQ4/ContextWrappers.pm
+++ b/inc/ZMQ4/ContextWrappers.pm
@@ -61,15 +61,17 @@ sub z85_encode {
     
     my $dest_buf = malloc(41);
     
-    $self->check_error(
+    my $checked_data = substr($data, 0, 32);
+    
+    $self->check_null(
         'zmq_z85_encode',
-        zmq_z85_encode( $dest_buf, $data, length($data) )
+        zmq_z85_encode( $dest_buf, $checked_data, length($checked_data) )
     );
     
     my $dest = buffer_to_scalar($dest_buf, 41);
     free($dest_buf);
     
-    return substr( $dest, 0, -1 );
+    return $dest;
 }
 )}
 
@@ -79,7 +81,7 @@ sub z85_decode {
     
     my $dest_buf = malloc(32);
     
-    $self->check_error(
+    $self->check_null(
         'zmq_z86_decode',
         zmq_z85_decode($dest_buf, $string)
     );

--- a/inc/ZMQ4/ContextWrappers.pm
+++ b/inc/ZMQ4/ContextWrappers.pm
@@ -55,4 +55,41 @@ sub curve_keypair {
 }
 )}
 
+sub z85_encode_tt {q(
+sub z85_encode {
+    my ($self, $data) = @_;
+    
+    my $dest_buf = malloc(41);
+    
+    $self->check_error(
+        'zmq_z85_encode',
+        zmq_z85_encode( $dest_buf, $data, length($data) )
+    );
+    
+    my $dest = buffer_to_scalar($dest_buf, 41);
+    free($dest_buf);
+    
+    return substr( $dest, 0, -1 );
+}
+)}
+
+sub z85_decode_tt {q(
+sub z85_decode {
+    my ($self, $string) = @_;
+    
+    my $dest_buf = malloc(32);
+    
+    $self->check_error(
+        'zmq_z86_decode',
+        zmq_z85_decode($dest_buf, $string)
+    );
+    
+    my $dest = buffer_to_scalar($dest_buf, 32);
+    free($dest_buf);
+    
+    return $dest;
+}
+)}
+
+
 1;

--- a/lib/ZMQ/FFI/ContextRole.pm
+++ b/lib/ZMQ/FFI/ContextRole.pm
@@ -52,6 +52,8 @@ requires qw(
     device
     destroy
     curve_keypair
+    z85_encode
+    z85_decode
     has_capability
 );
 

--- a/lib/ZMQ/FFI/ZMQ4/Raw.pm
+++ b/lib/ZMQ/FFI/ZMQ4/Raw.pm
@@ -133,6 +133,18 @@ sub load {
         ['zmq_curve_keypair' => "${target}::zmq_curve_keypair"]
             => ['opaque', 'opaque'] => 'int'
     );
+    
+    $ffi->attach(
+        # char *zmq_z85_encode (char *dest, const uint8_t *data, size_t size);
+        ['zmq_z85_encode' => "${target}::zmq_z85_encode"]
+            => ['opaque', 'string', 'size_t'] => 'pointer'
+    );
+    
+    $ffi->attach(
+        # uint8_t *zmq_z85_decode (uint8_t *dest, const char *string);
+        ['zmq_z85_decode' => "${target}::zmq_z85_decode"]
+            => ['opaque', 'string'] => 'pointer'
+    );
 }
 
 1;

--- a/lib/ZMQ/FFI/ZMQ4_1/Raw.pm
+++ b/lib/ZMQ/FFI/ZMQ4_1/Raw.pm
@@ -133,6 +133,18 @@ sub load {
         ['zmq_curve_keypair' => "${target}::zmq_curve_keypair"]
             => ['opaque', 'opaque'] => 'int'
     );
+    
+    $ffi->attach(
+        # char *zmq_z85_encode (char *dest, const uint8_t *data, size_t size);
+        ['zmq_z85_encode' => "${target}::zmq_z85_encode"]
+            => ['opaque', 'string', 'size_t'] => 'pointer'
+    );
+    
+    $ffi->attach(
+        # uint8_t *zmq_z85_decode (uint8_t *dest, const char *string);
+        ['zmq_z85_decode' => "${target}::zmq_z85_decode"]
+            => ['opaque', 'string'] => 'pointer'
+    );
 
     $ffi->attach(
         # int zmq_has (const char *capability);

--- a/t/z85_encoding.t
+++ b/t/z85_encoding.t
@@ -15,14 +15,14 @@ my ($major, $minor) = $c->version();
 if ($major == 4) {
     if ($minor >= 1) {
         if ($c->has_capability("curve")) {
-            my $encoded = '5B3nU@4Uu5n8+[&(Kv2]3G(5%nx:#XIb7iPP(3bc';
+            my ($encoded, $priv) = $c->curve_keypair;
             
             my $decoded = $c->z85_decode( $encoded );
             my $recoded = $c->z85_encode( $decoded );
             
             is
-                $encoded,
-                $recoded;
+                $recoded,
+                $encoded;
 
         } else {
             # zmq >= 4.1 - libsodium is not installed, do nothing

--- a/t/z85_encoding.t
+++ b/t/z85_encoding.t
@@ -1,0 +1,55 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Warnings;
+use Test::Exception;
+
+use ZMQ::FFI;
+use ZMQ::FFI::Constants qw(ZMQ_REQ ZMQ_REP ZMQ_CURVE_SERVER ZMQ_CURVE_SECRETKEY 
+                           ZMQ_CURVE_PUBLICKEY ZMQ_CURVE_SERVERKEY);
+
+my $c = ZMQ::FFI->new();
+
+my ($major, $minor) = $c->version();
+
+if ($major == 4) {
+    if ($minor >= 1) {
+        if ($c->has_capability("curve")) {
+            my $encoded = '5B3nU@4Uu5n8+[&(Kv2]3G(5%nx:#XIb7iPP(3bc';
+            
+            my $decoded = $c->z85_decode( $encoded );
+            my $recoded = $c->z85_encode( $decoded );
+            
+            is
+                $encoded,
+                $recoded;
+
+        } else {
+            # zmq >= 4.1 - libsodium is not installed, do nothing
+        }
+    } else {
+	# zmq == 4.0 - can't assume libsodium is installed or uninstalled
+	# so we can't run the z85_encode() method
+	
+	# verify that has capability is not implemented before 4.1
+	throws_ok { $c->has_capability() }
+	            qr'has_capability not available',
+                    'threw unimplemented error for < 4.1';
+    }
+} 
+else {
+    # zmq < 4.x - z85_encode / z85_decode and has capability are not implemented
+    throws_ok { $c->z85_encode() }
+                qr'z85_encode not available',
+                'threw unimplemented error in < 4.x';   
+
+    throws_ok { $c->z85_decode() }
+                qr'z85_decode not available',
+                'threw unimplemented error in < 4.x';   
+                
+    throws_ok { $c->has_capability() }
+                qr'has_capability not available',
+                'threw unimplemented error for < 4.1';
+}
+
+done_testing;


### PR DESCRIPTION
These changes help writing Zeromq Authentication Protocol authenticator subs, as the key returned in the Auth Request message has been decoded and doesn't match what was sent into perl.﻿
