### PR TITLE
Added zmq_socket_monitor bindings to socket

### DIFF
--- a/inc/ZMQ2/SocketWrappers.pm
+++ b/inc/ZMQ2/SocketWrappers.pm
@@ -474,4 +474,30 @@ sub close {
 }
 )}
 
+sub monitor_tt {q(
+sub monitor {
+    my ($self) = @_;
+
+    [% closed_socket_check %]
+
+    $self->bad_version(
+        $self->verstr,
+        "monitor not available in zmq 2.x"
+    );
+}
+)}
+
+sub recv_event_tt {q(
+sub recv_event {
+    my ($self) = @_;
+
+    [% closed_socket_check %]
+
+    $self->bad_version(
+        $self->verstr,
+        "recv_event not available in zmq 2.x"
+    );
+}
+)}
+
 1;

--- a/inc/ZMQ4/SocketWrappers.pm
+++ b/inc/ZMQ4/SocketWrappers.pm
@@ -5,4 +5,18 @@ use namespace::clean;
 
 extends 'inc::ZMQ3::SocketWrappers';
 
+sub recv_event_tt {q(
+sub recv_event {
+    my ($self, $flags) = @_;
+
+    [% closed_socket_check %]
+
+    my ($event, $endpoint) = $self->recv_multipart($flags);
+
+    my ($id, $value) = unpack('S L', $event);
+
+    return ($id, $value, $endpoint);
+}
+)}
+
 1;

--- a/lib/ZMQ/FFI/ZMQ3/Raw.pm
+++ b/lib/ZMQ/FFI/ZMQ3/Raw.pm
@@ -127,6 +127,12 @@ sub load {
         ['zmq_errno' => "${target}::zmq_errno"]
             => [] => 'int'
     );
+
+    $ffi->attach(
+        # int zmq_socket_monitor (void *socket, char *addr, int events);
+        ['zmq_socket_monitor' => "${target}::zmq_socket_monitor"]
+            => ['pointer', 'string', 'int'] => 'int'
+    );
 }
 
 1;

--- a/lib/ZMQ/FFI/ZMQ4/Raw.pm
+++ b/lib/ZMQ/FFI/ZMQ4/Raw.pm
@@ -145,6 +145,12 @@ sub load {
         ['zmq_z85_decode' => "${target}::zmq_z85_decode"]
             => ['opaque', 'string'] => 'pointer'
     );
+
+    $ffi->attach(
+        # int zmq_socket_monitor (void *socket, char *endpoint, int events);
+        ['zmq_socket_monitor' => "${target}::zmq_socket_monitor"]
+            => ['pointer', 'string', 'int'] => 'int'
+    );
 }
 
 1;

--- a/lib/ZMQ/FFI/ZMQ4_1/Raw.pm
+++ b/lib/ZMQ/FFI/ZMQ4_1/Raw.pm
@@ -151,6 +151,12 @@ sub load {
         ['zmq_has' => "${target}::zmq_has"]
             => ['string'] => 'int'
     );
+
+    $ffi->attach(
+        # int zmq_socket_monitor (void *socket, char *endpoint, int events);
+        ['zmq_socket_monitor' => "${target}::zmq_socket_monitor"]
+            => ['pointer', 'string', 'int'] => 'int'
+    );
 }
 
 1;

--- a/scripts/gen_zmq_constants.pl
+++ b/scripts/gen_zmq_constants.pl
@@ -43,11 +43,14 @@ for my $r (@repos) {
         my %constants =
             map  { split '\s+' }
             grep { !/ZMQ_VERSION/ }
-            grep { /\b(ZMQ_[^ ]+\s+(0x)?\d+)/; $_ = $1; }
+            grep { /\b(ZMQ_[^ ]+\s+(0x)?[0-9A-F]+)/; $_ = $1; }
             qx(git show $version:include/zmq.h);
 
-        while ( my ($constant,$value) = each %constants ) {
+        if ($version =~ m/^v3\./ && !defined($constants{ZMQ_EVENT_ALL})) {
+            $constants{ZMQ_EVENT_ALL} = 65535;
+        }
 
+        while ( my ($constant,$value) = each %constants ) {
             # handle hex values
             if ( $value =~ m/^0x/ ) {
                 $value = hex($value);

--- a/t/monitor.t
+++ b/t/monitor.t
@@ -1,0 +1,169 @@
+use strict;
+use warnings;
+
+use v5.10;
+
+use Test::More;
+use Test::Warnings;
+use Sys::SigAction qw(timeout_call);
+
+use ZMQ::FFI qw(
+    ZMQ_DEALER ZMQ_PAIR
+
+    ZMQ_EVENT_ALL
+    ZMQ_EVENT_CONNECTED
+    ZMQ_EVENT_CONNECT_DELAYED
+    ZMQ_EVENT_CONNECT_RETRIED
+    ZMQ_EVENT_LISTENING
+    ZMQ_EVENT_BIND_FAILED
+    ZMQ_EVENT_ACCEPTED
+    ZMQ_EVENT_ACCEPT_FAILED
+    ZMQ_EVENT_CLOSED
+    ZMQ_EVENT_CLOSE_FAILED
+    ZMQ_EVENT_DISCONNECTED
+    ZMQ_EVENT_MONITOR_STOPPED
+    ZMQ_EVENT_HANDSHAKE_SUCCEEDED
+);
+
+sub dump_event {
+    my ($socket) = @_;
+
+    my ($major, $minor, $patch) = $socket->version;
+
+    say "----------------------------------------";
+
+    for my $message ($socket->recv_multipart()) {
+        my $msg_len = length($message);
+
+        my $is_text = 1;
+
+        CHECK_TEXT:
+        for (my $i = 0; $i < $msg_len; $i++) {
+            my $c = ord(substr($message, $i, 1));
+
+            if ($c < 32 || $c > 126) {
+                $is_text = 0;
+                last CHECK_TEXT;
+            }
+        }
+
+        printf "[%03d] ", $msg_len;
+
+        if ($is_text) {
+            say $message;
+        }
+        else {
+            if ($major == 3) {
+                say unpack('H*', $message);
+                my ($event, $ptr, $fd) = unpack('i x4 p i x4', $message);
+                say "$event / $ptr / $fd";
+            }
+            else {
+                my ($event, $data) = unpack('S L', $message);
+                say "$event / $data";
+            }
+        }
+    }
+}
+
+subtest 'monitor', sub {
+    my $timed_out = timeout_call 5, sub {
+        my $ctx = ZMQ::FFI->new();
+
+        my ($major, $minor, $patch) = $ctx->version();
+
+        if ($major < 3) {
+            pass('ZMQ2 does not support zmq_socket_monitor');
+            return;
+        }
+
+        my $s = $ctx->socket(ZMQ_DEALER);
+        my $c = $ctx->socket(ZMQ_DEALER);
+
+        $s->monitor('inproc://monitor-server', ZMQ_EVENT_ALL);
+        $c->monitor('inproc://monitor-client', ZMQ_EVENT_ALL);
+
+        my $ms = $ctx->socket(ZMQ_PAIR);
+        my $mc = $ctx->socket(ZMQ_PAIR);
+        my $ts = $ctx->socket(ZMQ_PAIR);
+
+        $ms->connect('inproc://monitor-server');
+        $mc->connect('inproc://monitor-client');
+
+        my $endpoint = "ipc:///tmp/test-zmq-ffi-$$";
+
+        $s->bind($endpoint);
+
+        my ($id, $value, $data) = $ms->recv_event();
+
+        cmp_ok $id, '==', ZMQ_EVENT_LISTENING,
+            'Received ZMQ_EVENT_LISTENING event from server socket';
+
+        cmp_ok $data, 'eq', $endpoint,
+            "Received endpoint is $endpoint";
+
+        $c->connect($endpoint);
+
+        ($id, $value, $data) = $ms->recv_event();
+
+        cmp_ok $id, '==', ZMQ_EVENT_ACCEPTED,
+            'Received ZMQ_EVENT_ACCEPTED event from server socket';
+
+        cmp_ok $data, 'eq', $endpoint,
+            "Received endpoint is $endpoint";
+
+        ($id, $value, $data) = $mc->recv_event();
+
+        cmp_ok $id, '==', ZMQ_EVENT_CONNECTED,
+            'Received ZMQ_EVENT_CONNECTED event from client socket';
+
+        cmp_ok $data, 'eq', $endpoint,
+            "Received endpoint is $endpoint";
+
+        $s->close();
+
+        # WARNING:
+        # ZMQ_EVENT_HANDSHAKE_SUCCEEDED event is happend from ZMQ 4.3.2
+        # with unknown reason and this situation seems like a bug so we need
+        # to change below test code after fixing this bug.
+        if ($major >= 4 && $minor >= 3 && $patch >= 2)
+        {
+            ($id, $value, $data) = $ms->recv_event();
+
+            cmp_ok $id, '==', ZMQ_EVENT_HANDSHAKE_SUCCEEDED
+                'Received ZMQ_EVENT_HANDSHAKE_SUCCEEDED event from server socket';
+
+            cmp_ok $data, 'eq', $endpoint,
+                "Received endpoint is $endpoint";
+
+            ($id, $value, $data) = $mc->recv_event();
+
+            cmp_ok $id, '==', ZMQ_EVENT_HANDSHAKE_SUCCEEDED
+                'Received ZMQ_EVENT_HANDSHAKE_SUCCEEDED event from client socket';
+
+            cmp_ok $data, 'eq', $endpoint,
+                "Received endpoint is $endpoint";
+        }
+
+        ($id, $value, $data) = $ms->recv_event();
+
+        cmp_ok $id, '==', ZMQ_EVENT_CLOSED,
+            'Received ZMQ_EVENT_CLOSED event from server socket';
+
+        cmp_ok $data, 'eq', $endpoint,
+            "Received endpoint is $endpoint";
+
+        ($id, $value, $data) = $mc->recv_event();
+
+        cmp_ok $id, '==', ZMQ_EVENT_DISCONNECTED,
+            'Received ZMQ_EVENT_DISCONNECTED event from client socket';
+
+        cmp_ok $data, 'eq', $endpoint,
+            "Received endpoint is $endpoint";
+    };
+
+    ok !$timed_out,
+       'implicit Socket close done correctly (ctx destruction does not hang)';
+};
+
+done_testing;


### PR DESCRIPTION
These changes support ZMQ socket monitoring features with ZMQ3/4.

Signed-off-by: Ji-Hyeon Gim <potatogim@gluesys.com>