### PR TITLE
MSWin32 compatibility and test portability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+
+jobs:
+  dist:
+    name: Make distribution using Dist::Zilla
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Make distribution
+        shell: bash
+        run: |
+          ./docker-run sh -c "
+                dzil authordeps --missing | cpanm -n;
+                dzil clean && dzil build --in build-dir"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: ./build-dir
+  test:
+    needs: dist
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+        perl: ['5']
+        perl-threaded: [false]
+        include:
+          - { os: 'ubuntu-latest', perl: "5.14" }
+          - { os: 'ubuntu-latest', perl: "5.16" }
+          - { os: 'ubuntu-latest', perl: "5.20" }
+          - { os: 'ubuntu-latest', perl: "5.30" }
+          - { os: 'ubuntu-latest', perl: "5.32" }
+          - { os: 'ubuntu-latest', perl: "5.32", perl-threaded: true }
+    name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
+
+    steps:
+      - name: Get dist artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+
+      - name: Set up perl
+        uses: shogo82148/actions-setup-perl@v1
+        if: matrix.os != 'windows-latest'
+        with:
+          perl-version: ${{ matrix.perl }}
+          multi-thread: ${{ matrix.perl-threaded }}
+      - name: Set up perl (Strawberry)
+        uses: shogo82148/actions-setup-perl@v1
+        if: matrix.os == 'windows-latest'
+        with:
+          distribution: 'strawberry'
+
+      - run: perl -V
+
+      - name: Set up ZeroMQ (homebrew)
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install zeromq
+
+      - name: Set up ZeroMQ (vcpkg)
+        if: matrix.os == 'windows-latest'
+        run: |
+          vcpkg install zeromq:x64-windows
+          copy C:/vcpkg/packages/zeromq_x64-windows/bin/libzmq*.dll libzmq.dll
+          echo $pwd.Path | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Install Perl deps
+        run: |
+          cpanm --notest --installdeps .
+
+      - name: Run tests
+        run: |
+          cpanm --verbose --test-only .

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -15,7 +15,12 @@ jobs:
         uses: actions/checkout@v2
       - name: dzil test
         run: |
-          ./docker-run dzil test
+          ./docker-run sh -c "
+                dzil authordeps --missing | cpanm -n;
+                dzil test"
       - name: docker-test-install
         run: |
-          ./scripts/docker-test-install
+          ./docker-run sh -c "
+                dzil authordeps --missing | cpanm -n;
+                dzil clean && dzil build;
+                cpanm -v ZMQ-FFI-*.tar.gz"

--- a/dist.ini
+++ b/dist.ini
@@ -37,6 +37,7 @@ version_regexp = ^(.+)$
 [PodWeaver]
 
 [AutoPrereqs]
+skip = ^Sys::SigAction
 [Prereqs / ConfigureRequires]
 FFI::Platypus = 0.86
 
@@ -47,6 +48,10 @@ Class::XSAccessor = 1.18
 Math::BigInt      = 1.997
 FFI::Platypus     = 0.86
 Import::Into      = 1.002005
+
+[DynamicPrereqs / Sys::SigAction]
+-condition = isnt_os('MSWin32')
+-body = test_requires('Sys::SigAction', '0')
 
 [Run::BeforeBuild]
 run = perl scripts/gen_zmq_constants.pl
@@ -66,6 +71,9 @@ run = rm -f lib/ZMQ/FFI/*/Socket.pm
 repo = zeromq/perlzmq
 
 [MetaJSON]
+
+[MetaNoIndex]
+directory = t
 
 [Meta::Contributors]
 contributor = Dave Lambley <github@davel.me.uk>

--- a/lib/ZMQ/FFI/Util.pm
+++ b/lib/ZMQ/FFI/Util.pm
@@ -30,10 +30,11 @@ sub zmq_soname {
     # we'll try the linker_name, then the sonames.
     #
     # If Linux extensions fail also try platform specific
-    # extensions (e.g. OS X) before giving up.
+    # extensions (e.g. OS X, MSWin32) before giving up.
     my @sonames = qw(
         libzmq.so    libzmq.so.5    libzmq.so.4    libzmq.so.3    libzmq.so.1
         libzmq.dylib libzmq.4.dylib libzmq.3.dylib libzmq.1.dylib
+        libzmq.dll
     );
 
     my $soname;

--- a/t/close.t
+++ b/t/close.t
@@ -20,7 +20,7 @@ subtest 'close with unsent messages', sub {
         my $ctx = ZMQ::FFI->new();
         my $s   = $ctx->socket(ZMQ_REQ);
 
-        $s->connect("ipc:///tmp/test-zmq-ffi-$$");
+        $s->connect(ZMQTest->endpoint("test-zmq-ffi-$$"));
         $s->send('ohhai');
     });
 

--- a/t/close.t
+++ b/t/close.t
@@ -3,18 +3,26 @@ use warnings;
 
 use Test::More;
 use Test::Warnings;
-use Sys::SigAction qw(timeout_call);
+use lib 't/lib';
+use ZMQTest;
+
+if( ZMQTest->platform_can_sigaction ) {
+    require Sys::SigAction;
+    Sys::SigAction->import(qw(timeout_call));
+} else {
+    plan skip_all => 'No Sys::SigAction';
+}
 
 use ZMQ::FFI qw(ZMQ_REQ);
 
 subtest 'close with unsent messages', sub {
-    my $timed_out = timeout_call 5, sub {
+    my $timed_out = timeout_call(5, sub {
         my $ctx = ZMQ::FFI->new();
         my $s   = $ctx->socket(ZMQ_REQ);
 
         $s->connect("ipc:///tmp/test-zmq-ffi-$$");
         $s->send('ohhai');
-    };
+    });
 
     ok !$timed_out,
        'implicit Socket close done correctly (ctx destruction does not hang)';

--- a/t/curve_keypair.t
+++ b/t/curve_keypair.t
@@ -3,6 +3,8 @@ use warnings;
 use Test::More;
 use Test::Warnings;
 use Test::Exception;
+use lib 't/lib';
+use ZMQTest;
 
 use ZMQ::FFI;
 use ZMQ::FFI::Constants qw(ZMQ_REQ ZMQ_REP ZMQ_CURVE_SERVER ZMQ_CURVE_SECRETKEY 
@@ -12,7 +14,7 @@ my $c = ZMQ::FFI->new();
 
 my ($major, $minor) = $c->version();
 
-my $e = "ipc:///tmp/test-zmq-ffi-$$";
+my $e = ZMQTest->endpoint("test-zmq-ffi-$$");
 
 if ($major == 4) {
     if ($minor >= 1) {

--- a/t/device.t
+++ b/t/device.t
@@ -4,12 +4,18 @@ use warnings;
 use Test::More;
 use Test::Warnings;
 use Test::Exception;
+use lib 't/lib';
+use ZMQTest;
 
 use ZMQ::FFI qw(ZMQ_STREAMER ZMQ_PUSH ZMQ_PULL);
 use ZMQ::FFI::Util qw(zmq_version);
 
 use Time::HiRes q(usleep);
 use POSIX ":sys_wait_h";
+
+if( ! ZMQTest->platform_can_fork ) {
+    plan skip_all => 'fork(2) unavailable';
+}
 
 my $server_address = "ipc:///tmp/test-zmq-ffi-$$-front";
 my $worker_address = "ipc:///tmp/test-zmq-ffi-$$-back";

--- a/t/device.t
+++ b/t/device.t
@@ -17,8 +17,8 @@ if( ! ZMQTest->platform_can_fork ) {
     plan skip_all => 'fork(2) unavailable';
 }
 
-my $server_address = "ipc:///tmp/test-zmq-ffi-$$-front";
-my $worker_address = "ipc:///tmp/test-zmq-ffi-$$-back";
+my $server_address = ZMQTest->endpoint("test-zmq-ffi-$$-front");
+my $worker_address = ZMQTest->endpoint("test-zmq-ffi-$$-back");
 
 my $device;
 

--- a/t/errors.t
+++ b/t/errors.t
@@ -4,6 +4,8 @@ use warnings;
 use Test::More;
 use Test::Warnings;
 use Test::Exception;
+use lib 't/lib';
+use ZMQTest;
 
 use FFI::Platypus;
 use Errno qw(EINVAL EAGAIN);
@@ -66,7 +68,7 @@ subtest 'fatal socket error' => sub {
 subtest 'socket recv error && die_on_error => false' => sub {
     my $ctx    = ZMQ::FFI->new();
     my $socket = $ctx->socket(ZMQ_REP);
-    $socket->bind("ipc:///tmp/test-zmq-ffi-$$");
+    $socket->bind(ZMQTest->endpoint("test-zmq-ffi-$$"));
 
     check_nonfatal_eagain($socket, 'recv', ZMQ_DONTWAIT);
 };
@@ -74,7 +76,7 @@ subtest 'socket recv error && die_on_error => false' => sub {
 subtest 'socket send error && die_on_error => false' => sub {
     my $ctx    = ZMQ::FFI->new();
     my $socket = $ctx->socket(ZMQ_DEALER);
-    $socket->bind("ipc:///tmp/test-zmq-ffi-$$");
+    $socket->bind(ZMQTest->endpoint("test-zmq-ffi-$$"));
 
     check_nonfatal_eagain($socket, 'send', 'ohhai', ZMQ_DONTWAIT);
 };
@@ -82,7 +84,7 @@ subtest 'socket send error && die_on_error => false' => sub {
 subtest 'socket recv_multipart error && die_on_error => false' => sub {
     my $ctx    = ZMQ::FFI->new();
     my $socket = $ctx->socket(ZMQ_REP);
-    $socket->bind("ipc:///tmp/test-zmq-ffi-$$");
+    $socket->bind(ZMQTest->endpoint("test-zmq-ffi-$$"));
 
     check_nonfatal_eagain($socket, 'recv_multipart', ZMQ_DONTWAIT);
 };
@@ -90,7 +92,7 @@ subtest 'socket recv_multipart error && die_on_error => false' => sub {
 subtest 'socket send_multipart error && die_on_error => false' => sub {
     my $ctx    = ZMQ::FFI->new();
     my $socket = $ctx->socket(ZMQ_DEALER);
-    $socket->bind("ipc:///tmp/test-zmq-ffi-$$");
+    $socket->bind(ZMQTest->endpoint("test-zmq-ffi-$$"));
 
     check_nonfatal_eagain(
         $socket, 'send_multipart', [qw(foo bar baz)], ZMQ_DONTWAIT

--- a/t/fd.t
+++ b/t/fd.t
@@ -13,7 +13,7 @@ if( ! ZMQTest->platform_zmq_fd_sockopt_is_fd ) {
 use AnyEvent;
 use ZMQ::FFI qw(ZMQ_PUSH ZMQ_PULL);
 
-my $endpoint = "ipc:///tmp/test-zmq-ffi-$$";
+my $endpoint = ZMQTest->endpoint("test-zmq-ffi-$$");
 my @expected = qw(foo bar baz);
 my $ctx      = ZMQ::FFI->new();
 

--- a/t/fd.t
+++ b/t/fd.t
@@ -3,6 +3,12 @@ use warnings;
 
 use Test::More;
 use Test::Warnings;
+use lib 't/lib';
+use ZMQTest;
+
+if( ! ZMQTest->platform_zmq_fd_sockopt_is_fd ) {
+    plan skip_all => 'Method get_fd() not implemented for platform';
+}
 
 use AnyEvent;
 use ZMQ::FFI qw(ZMQ_PUSH ZMQ_PULL);

--- a/t/fork-01.t
+++ b/t/fork-01.t
@@ -3,8 +3,14 @@ use warnings;
 
 use Test::More;
 use Test::Warnings;
+use lib 't/lib';
+use ZMQTest;
 
 use ZMQ::FFI qw(ZMQ_REQ);
+
+if( ! ZMQTest->platform_can_fork ) {
+    plan skip_all => 'fork(2) unavailable';
+}
 
 #
 # Test that we guard against trying to clean up context/sockets

--- a/t/fork-02.t
+++ b/t/fork-02.t
@@ -3,8 +3,14 @@ use warnings;
 
 use Test::More;
 use Test::Warnings;
+use lib 't/lib';
+use ZMQTest;
 
 use ZMQ::FFI qw(ZMQ_REQ);
+
+if( ! ZMQTest->platform_can_fork ) {
+    plan skip_all => 'fork(2) unavailable';
+}
 
 #
 # Test that we _do_ clean up contexts/sockets created in forked children

--- a/t/lib/ZMQTest.pm
+++ b/t/lib/ZMQTest.pm
@@ -1,0 +1,41 @@
+package ZMQTest;
+# ABSTRACT: Test helper library
+
+=head1 CLASS METHODS
+
+=head2 platform_can_fork
+
+Returns true if platform can use L<fork(2)> syscall.
+
+Returns false on C<MSWin32> which does not have a real L<fork(2)>.
+
+=cut
+sub platform_can_fork {
+	return $^O ne 'MSWin32';
+}
+
+=head2 platform_can_sigaction
+
+Returns true if platform can use L<Sys::SigAction>.
+
+Returns false on C<MSWin32> which does not have L<sigaction(2)>.
+
+=cut
+sub platform_can_sigaction {
+	return $^O ne 'MSWin32';
+}
+
+=head2 platform_zmq_fd_sockopt_is_fd
+
+Returns true if the ZeroMQ socket option C<ZMQ_FD> is a C runtime file
+descriptor (which is an C<int>).
+
+Returns false on C<MSWin32> where C<ZMQ_FD> is of type C<SOCKET>
+(which is a C<uint64>).
+
+=cut
+sub platform_zmq_fd_sockopt_is_fd {
+	return $^O ne 'MSWin32';
+}
+
+1;

--- a/t/lib/ZMQTest.pm
+++ b/t/lib/ZMQTest.pm
@@ -38,4 +38,33 @@ sub platform_zmq_fd_sockopt_is_fd {
 	return $^O ne 'MSWin32';
 }
 
+=head2 platform_can_transport_zmq_ipc
+
+Returns true if platform can use L<zmq_ipc(7)> transport.
+
+This is currently false on systems such as C<MSWin32> because they do not
+support Unix domain sockets.
+
+=cut
+sub platform_can_transport_zmq_ipc {
+	return $^O ne 'MSWin32';
+}
+
+=head2 endpoint
+
+  ZMQTest->endpoint($name)
+
+Returns an appropriate endpoint string that is supported on the current
+platform.
+
+=cut
+sub endpoint {
+	my ($class, $name) = @_;
+	if( $class->platform_can_transport_zmq_ipc ) {
+		return "ipc:///tmp/$name";
+	} else {
+		return "inproc://$name";
+	}
+}
+
 1;

--- a/t/monitor.t
+++ b/t/monitor.t
@@ -5,7 +5,15 @@ use v5.10;
 
 use Test::More;
 use Test::Warnings;
-use Sys::SigAction qw(timeout_call);
+use lib 't/lib';
+use ZMQTest;
+
+if( ZMQTest->platform_can_sigaction ) {
+    require Sys::SigAction;
+    Sys::SigAction->import(qw(timeout_call));
+} else {
+    plan skip_all => 'No Sys::SigAction';
+}
 
 use ZMQ::FFI qw(
     ZMQ_DEALER ZMQ_PAIR
@@ -67,7 +75,7 @@ sub dump_event {
 }
 
 subtest 'monitor', sub {
-    my $timed_out = timeout_call 5, sub {
+    my $timed_out = timeout_call(5, sub {
         my $ctx = ZMQ::FFI->new();
 
         my ($major, $minor, $patch) = $ctx->version();
@@ -160,7 +168,7 @@ subtest 'monitor', sub {
 
         cmp_ok $data, 'eq', $endpoint,
             "Received endpoint is $endpoint";
-    };
+    });
 
     ok !$timed_out,
        'implicit Socket close done correctly (ctx destruction does not hang)';

--- a/t/monitor.t
+++ b/t/monitor.t
@@ -98,7 +98,7 @@ subtest 'monitor', sub {
         $ms->connect('inproc://monitor-server');
         $mc->connect('inproc://monitor-client');
 
-        my $endpoint = "ipc:///tmp/test-zmq-ffi-$$";
+        my $endpoint = ZMQTest->endpoint("test-zmq-ffi-$$");
 
         $s->bind($endpoint);
 

--- a/t/multipart.t
+++ b/t/multipart.t
@@ -3,13 +3,15 @@ use warnings;
 
 use Test::More;
 use Test::Warnings;
+use lib 't/lib';
+use ZMQTest;
 
 use ZMQ::FFI qw(ZMQ_DEALER ZMQ_ROUTER ZMQ_DONTWAIT ZMQ_SNDMORE);
 
 use Scalar::Util qw(blessed);
 use Sub::Override;
 
-my $endpoint = "ipc:///tmp/test-zmq-ffi-$$";
+my $endpoint = ZMQTest->endpoint("test-zmq-ffi-$$");
 my $ctx      = ZMQ::FFI->new();
 
 my $d = $ctx->socket(ZMQ_DEALER);

--- a/t/options.t
+++ b/t/options.t
@@ -4,6 +4,8 @@ use warnings;
 use Test::More;
 use Test::Warnings;
 use Math::BigInt;
+use lib 't/lib';
+use ZMQTest;
 
 use ZMQ::FFI qw(:all);
 use ZMQ::FFI::Util qw(zmq_version);
@@ -63,7 +65,7 @@ sub {
     my $ctx = ZMQ::FFI->new();
     my $s   = $ctx->socket(ZMQ_DEALER);
 
-    my $endpoint = "ipc:///tmp/test-zmq-ffi-$$";
+    my $endpoint = ZMQTest->endpoint("test-zmq-ffi-$$");
     $s->bind($endpoint);
 
     is $s->get(ZMQ_LAST_ENDPOINT, 'string'), $endpoint, 'got last endpoint';

--- a/t/proxy.t
+++ b/t/proxy.t
@@ -3,11 +3,17 @@ use warnings;
 
 use Test::More;
 use Test::Warnings;
+use lib 't/lib';
+use ZMQTest;
 
 use ZMQ::FFI qw(ZMQ_PUSH ZMQ_PULL);
 
 use Time::HiRes q(usleep);
 use POSIX ":sys_wait_h";
+
+if( ! ZMQTest->platform_can_fork ) {
+    plan skip_all => 'fork(2) unavailable';
+}
 
 my $server_address = "ipc:///tmp/test-zmq-ffi-$$-front";
 my $worker_address = "ipc:///tmp/test-zmq-ffi-$$-back";

--- a/t/proxy.t
+++ b/t/proxy.t
@@ -15,8 +15,8 @@ if( ! ZMQTest->platform_can_fork ) {
     plan skip_all => 'fork(2) unavailable';
 }
 
-my $server_address = "ipc:///tmp/test-zmq-ffi-$$-front";
-my $worker_address = "ipc:///tmp/test-zmq-ffi-$$-back";
+my $server_address = ZMQTest->endpoint("test-zmq-ffi-$$-front");
+my $worker_address = ZMQTest->endpoint("test-zmq-ffi-$$-back");
 
 # Set up the proxy in its own process
 my $proxy = fork;

--- a/t/pubsub.t
+++ b/t/pubsub.t
@@ -3,6 +3,8 @@ use warnings;
 
 use Test::More;
 use Test::Warnings;
+use lib 't/lib';
+use ZMQTest;
 
 use ZMQ::FFI qw(ZMQ_PUB ZMQ_SUB ZMQ_DONTWAIT);
 
@@ -10,7 +12,7 @@ use Time::HiRes q(usleep);
 
 subtest 'pubsub',
 sub {
-    my $endpoint = "ipc:///tmp/test-zmq-ffi-$$";
+    my $endpoint = ZMQTest->endpoint("test-zmq-ffi-$$");
 
     my $ctx = ZMQ::FFI->new();
 

--- a/t/router-req.t
+++ b/t/router-req.t
@@ -3,13 +3,15 @@ use warnings;
 
 use Test::More;
 use Test::Warnings;
+use lib 't/lib';
+use ZMQTest;
 
 use ZMQ::FFI qw(ZMQ_ROUTER ZMQ_REQ);
 
 use Time::HiRes q(usleep);
 
 subtest 'router-req', sub {
-    my $endpoint = "ipc:///tmp/test-zmq-ffi-$$";
+    my $endpoint = ZMQTest->endpoint("test-zmq-ffi-$$");
 
     my $ctx = ZMQ::FFI->new();
 

--- a/t/send_recv.t
+++ b/t/send_recv.t
@@ -2,10 +2,12 @@ use strict;
 use warnings;
 use Test::More;
 use Test::Warnings;
+use lib 't/lib';
+use ZMQTest;
 
 use ZMQ::FFI qw(ZMQ_REQ ZMQ_REP);
 
-my $endpoint = "ipc:///tmp/test-zmq-ffi-$$";
+my $endpoint = ZMQTest->endpoint("test-zmq-ffi-$$");
 my $ctx      = ZMQ::FFI->new( threads => 1 );
 
 my $s1 = $ctx->socket(ZMQ_REQ);

--- a/t/unbind.t
+++ b/t/unbind.t
@@ -3,10 +3,12 @@ use warnings;
 use Test::More;
 use Test::Warnings;
 use Test::Exception;
+use lib 't/lib';
+use ZMQTest;
 
 use ZMQ::FFI qw(ZMQ_REQ ZMQ_REP ZMQ_LAST_ENDPOINT);
 
-my $e = "ipc:///tmp/test-zmq-ffi-$$";
+my $e = ZMQTest->endpoint("test-zmq-ffi-$$");
 
 my $c = ZMQ::FFI->new();
 

--- a/t/unicode.t
+++ b/t/unicode.t
@@ -5,10 +5,12 @@ use utf8;
 use Test::More;
 use Test::Warnings;
 use List::Util qw(sum);
+use lib 't/lib';
+use ZMQTest;
 
 use ZMQ::FFI qw(ZMQ_PUSH ZMQ_PULL);
 
-my $endpoint = "ipc:///tmp/test-zmq-ffi-$$";
+my $endpoint = ZMQTest->endpoint("test-zmq-ffi-$$");
 my $ctx      = ZMQ::FFI->new();
 
 my $s1 = $ctx->socket(ZMQ_PUSH);


### PR DESCRIPTION
This PR replaces <https://github.com/zeromq/perlzmq/pull/44>.

- Add generic CI workflow
- MSWin32 compatibility
- Use platform-specific endpoints for testing connections
