### PR TITLE
Optional support for Alien::ZMQ::latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
         perl: ['5']
         perl-threaded: [false]
+        alien: [false, true]
         include:
           - { os: 'ubuntu-latest', perl: "5.14" }
           - { os: 'ubuntu-latest', perl: "5.16" }
@@ -39,7 +40,7 @@ jobs:
           - { os: 'ubuntu-latest', perl: "5.30" }
           - { os: 'ubuntu-latest', perl: "5.32" }
           - { os: 'ubuntu-latest', perl: "5.32", perl-threaded: true }
-    name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
+    name: Perl ${{ matrix.perl }} on ${{ matrix.os }}, ${{ matrix.alien }}
 
     steps:
       - name: Get dist artifact
@@ -62,16 +63,21 @@ jobs:
       - run: perl -V
 
       - name: Set up ZeroMQ (homebrew)
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-latest' && ! matrix.alien
         run: |
           brew install zeromq
 
       - name: Set up ZeroMQ (vcpkg)
-        if: matrix.os == 'windows-latest'
+        if: matrix.os == 'windows-latest' && ! matrix.alien
         run: |
           vcpkg install zeromq:x64-windows
           copy C:/vcpkg/packages/zeromq_x64-windows/bin/libzmq*.dll libzmq.dll
           echo $pwd.Path | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Install Alien::ZMQ::latest
+        if: matrix.alien
+        run: |
+          cpanm -nq Alien::ZMQ::latest
 
       - name: Install Perl deps
         run: |

--- a/dist.ini
+++ b/dist.ini
@@ -7,8 +7,10 @@ copyright_holder = Dylan Cali
 -bundle = @Basic
 -remove = MakeMaker
 
+; authordep Dist::Zilla::Plugin::FFI::CheckLib = 1.05
 [FFI::CheckLib]
 lib = zmq
+alien = Alien::ZMQ::latest
 
 [MakeMaker::Awesome]
 delimiter = |
@@ -38,8 +40,12 @@ version_regexp = ^(.+)$
 
 [AutoPrereqs]
 skip = ^Sys::SigAction
+skip = ^Alien::ZMQ::latest
 [Prereqs / ConfigureRequires]
 FFI::Platypus = 0.86
+
+[Prereqs / ConfigureSuggests]
+Alien::ZMQ::latest = 0.007
 
 [Prereqs / RuntimeRequires]
 perl              = 5.010
@@ -48,6 +54,9 @@ Class::XSAccessor = 1.18
 Math::BigInt      = 1.997
 FFI::Platypus     = 0.86
 Import::Into      = 1.002005
+
+[Prereqs / RuntimeSuggests]
+Alien::ZMQ::latest = 0.007
 
 [DynamicPrereqs / Sys::SigAction]
 -condition = isnt_os('MSWin32')

--- a/lib/ZMQ/FFI/Util.pm
+++ b/lib/ZMQ/FFI/Util.pm
@@ -37,6 +37,10 @@ sub zmq_soname {
         libzmq.dll
     );
 
+    if( eval { require Alien::ZMQ::latest; 1 } ) {
+        push @sonames, Alien::ZMQ::latest->dynamic_libs;
+    }
+
     my $soname;
     FIND_SONAME:
     for (@sonames) {


### PR DESCRIPTION
- Add optional support for using Alien::ZMQ::latest
- GHA: Test Alien::ZMQ::latest support

---

Test using:

```shell
$ cat > Dockerfile.azl <<EOF; docker build -f Dockerfile.azl . -t perlzmq:azl
FROM calid/zmq-ffi-testenv:ubuntu as build
WORKDIR /zmq-ffi
COPY . /zmq-ffi
RUN dzil authordeps --missing | cpanm -n && dzil clean && dzil build --in build-dir

FROM perl:5.34 as install
COPY --from=build /zmq-ffi/build-dir /zmq-ffi/build-dir
RUN cpanm -nq Alien::ZMQ::latest && cpanm --verbose /zmq-ffi/build-dir
EOF
```
