### PR TITLE
Fix build needed for release

### DIFF
--- a/scripts/docker-release-shell
+++ b/scripts/docker-release-shell
@@ -2,9 +2,9 @@
 docker run --rm -i -t \
     -e SHELL=/bin/bash \
     -v $(pwd):/zmq-ffi \
-    -v /home/calid/.ssh:/root/.ssh \
-    -v /home/calid/.pause:/root/.pause \
-    -v /home/calid/.gitconfig:/root/.gitconfig \
-    -v /home/calid/.gitignore:/root/.gitignore \
+    -v $HOME/.ssh:/root/.ssh \
+    -v $HOME/.pause:/root/.pause \
+    -v $HOME/.gitconfig:/root/.gitconfig \
+    -v $HOME/.gitignore:/root/.gitignore \
     -w /zmq-ffi \
     calid/zmq-ffi-testenv:ubuntu /bin/bash

--- a/scripts/gen_zmq_constants.pl
+++ b/scripts/gen_zmq_constants.pl
@@ -43,6 +43,17 @@ for my $r (@repos) {
         my %constants =
             map  { split '\s+' }
             grep { !/ZMQ_VERSION/ }
+            # Skip ZMQ_GROUP_MAX_LENGTH.
+            #
+            # The value for ZMQ_GROUP_MAX_LENGTH changed from 15 to 255 between
+            # libzmq versions v4.3.2 and v4.3.3.
+            #
+            # - <https://github.com/zeromq/libzmq/pull/3822>,
+            # - <https://github.com/zeromq/libzmq/commit/05194eb549b3d3e83ef1b75fa8f2d7aaa8d43c00>.
+            #
+            # This is for the RADIO-DISH protocol that was introduced as a
+            # draft in v4.2.0 <https://rfc.zeromq.org/spec/48/>.
+            grep { !/ZMQ_GROUP_MAX_LENGTH/ }
             grep { /\b(ZMQ_[^ ]+\s+(0x)?[0-9A-F]+)/; $_ = $1; }
             qx(git show $version:include/zmq.h);
 


### PR DESCRIPTION
The value for `ZMQ_GROUP_MAX_LENGTH` changed from 15 to 255 between libzmq versions v4.3.2 and v4.3.3 <https://github.com/zeromq/libzmq/pull/3822> which causes an error during the build. This constant is part of the RADIO-DISH protocol <https://rfc.zeromq.org/spec/48/> which is currently a draft.
