### PR TITLE
GHA: disable fail-fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     needs: dist
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         perl: ['5']


### PR DESCRIPTION
This allows for some jobs to fail without cancelling the whole workflow.

Currently there is an issue with the Vcpkg build that has been identified: <https://github.com/microsoft/vcpkg/pull/22681#issuecomment-1061312320>.
